### PR TITLE
Fix layout of help page

### DIFF
--- a/qml/pages/Help.qml
+++ b/qml/pages/Help.qml
@@ -7,9 +7,13 @@ Page {
 
     SilicaFlickable {
         anchors.fill: parent
-        contentHeight: header.height + text.height + Theme.paddingLarge
+        contentHeight: column.height + Theme.paddingLarge
         contentWidth: parent.width
         VerticalScrollDecorator {}
+        Column {
+            id: column
+            width: parent.width
+
             PageHeader {
                 id: header
                 title: qsTr("Help")
@@ -17,16 +21,8 @@ Page {
 
             Text {
                 id: text
-                anchors {
-                    top: parent.top
-                    left: parent.left
-                    right: parent.right
-                    leftMargin: 20
-                    rightMargin: 20
-                    topMargin: 40
-                }
-
-                width: parent.width
+                x: Theme.horizontalPageMargin
+                width: parent.width - 2*x
                 wrapMode: Text.WordWrap
                 color: Theme.primaryColor
                 linkColor: Theme.highlightColor
@@ -52,5 +48,6 @@ Page {
 
 
             }
+        }
     }
 }

--- a/translations/harbour-allradio-da.ts
+++ b/translations/harbour-allradio-da.ts
@@ -1175,62 +1175,62 @@
 <context>
     <name>Help</name>
     <message>
-        <location filename="../qml/pages/Help.qml" line="15"/>
+        <location filename="../qml/pages/Help.qml" line="19"/>
         <source>Help</source>
         <translation>Hjælp</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="33"/>
+        <location filename="../qml/pages/Help.qml" line="29"/>
         <source>Opening webpage</source>
         <translation>Åbner webside</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="37"/>
+        <location filename="../qml/pages/Help.qml" line="33"/>
         <source>Basics</source>
         <translation>Grundlæggende</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="38"/>
+        <location filename="../qml/pages/Help.qml" line="34"/>
         <source>Choose country by clicking the flag/name, then click the channel you want to listen to</source>
         <translation>Vælg land ved at klikke på landets flag/navn, klik derefter på den kanal du vil lytte til</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="40"/>
+        <location filename="../qml/pages/Help.qml" line="36"/>
         <source>When playing you will see the name and country-flag of the current playing radio station at the bottom of the screen.</source>
         <translation>Under afspilning ser du i bunden af skærmen flag og navn på den nuværende afspillende radiokanal.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="41"/>
+        <location filename="../qml/pages/Help.qml" line="37"/>
         <source>You can change the country selection between list and icons by flicking down and select &apos;show as list&apos; alt. &apos;show as grid&apos;</source>
         <translation>Du kan få vist lande som ikoner eller liste ved at svirpe ned og vælge enten &apos;vis som liste&apos; eller &apos;vis som ikoner&apos;</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="43"/>
+        <location filename="../qml/pages/Help.qml" line="39"/>
         <source>Searching</source>
         <translation>Søgning</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="45"/>
+        <location filename="../qml/pages/Help.qml" line="41"/>
         <source>When you have clicked on the country and are in the channels page, you can click the looking-glass at the top of the list to search/filter the selection based on channel name</source>
         <translation>Når du har valgt land og befinder dig på siden med kanaler, kan du klikke på forstørrelsesglasset opp i toppen af skærmen og søge/filtrere udvalget af stationer baseret på deres navn</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="47"/>
+        <location filename="../qml/pages/Help.qml" line="43"/>
         <source>Sleeptimer</source>
         <translation>Indslumringstimer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>Flick down and select sleeptimer, then set the time in minutes until you want the radio to stop playing</source>
         <translation>Svirp ned og vælg indslumringstimer, sæt derefter tiden i minutter du vil at radionen skal afspille inden den stopper</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>More</source>
         <translation>Øvrigt</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="50"/>
+        <location filename="../qml/pages/Help.qml" line="46"/>
         <source>This help is a draft! It may be updated?! :-)</source>
         <translation>Denne hjælp er et udkast! Den kan blive ændret?! :-)</translation>
     </message>

--- a/translations/harbour-allradio-es.ts
+++ b/translations/harbour-allradio-es.ts
@@ -1175,62 +1175,62 @@
 <context>
     <name>Help</name>
     <message>
-        <location filename="../qml/pages/Help.qml" line="15"/>
+        <location filename="../qml/pages/Help.qml" line="19"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="33"/>
+        <location filename="../qml/pages/Help.qml" line="29"/>
         <source>Opening webpage</source>
         <translation>Abriendo página Web</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="37"/>
+        <location filename="../qml/pages/Help.qml" line="33"/>
         <source>Basics</source>
         <translation>Básica</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="38"/>
+        <location filename="../qml/pages/Help.qml" line="34"/>
         <source>Choose country by clicking the flag/name, then click the channel you want to listen to</source>
         <translation>Elige el país haciendo clic en la bandera/nombre, después haz clic en el canal que quieres escuchar</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="40"/>
+        <location filename="../qml/pages/Help.qml" line="36"/>
         <source>When playing you will see the name and country-flag of the current playing radio station at the bottom of the screen.</source>
         <translation>En la parte inferior de la pantalla se mostrará el nombre y bandera del país de la estación de radio que se está reproduciendo.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="41"/>
+        <location filename="../qml/pages/Help.qml" line="37"/>
         <source>You can change the country selection between list and icons by flicking down and select &apos;show as list&apos; alt. &apos;show as grid&apos;</source>
         <translation>Puedes elegir entre lista o iconos a la hora de seleccionar el país, deslizando hacia abajo y seleccionando &apos;mostrar como lista&apos; o &apos;mostrar como cuadrícula&apos;</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="43"/>
+        <location filename="../qml/pages/Help.qml" line="39"/>
         <source>Searching</source>
         <translation>Búsqueda</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="45"/>
+        <location filename="../qml/pages/Help.qml" line="41"/>
         <source>When you have clicked on the country and are in the channels page, you can click the looking-glass at the top of the list to search/filter the selection based on channel name</source>
         <translation>Cuando haces clic en el país y accedes a la página de canales, puedes buscar/filtrar por nombre del canal si haces clic en la lupa, en la parte superior de la lista</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="47"/>
+        <location filename="../qml/pages/Help.qml" line="43"/>
         <source>Sleeptimer</source>
         <translation>Temporizador</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>Flick down and select sleeptimer, then set the time in minutes until you want the radio to stop playing</source>
         <translation>Desliza hacia abajo y selecciona el temporizador, después configura el tiempo en minutos que deseas que la radio esté funcionando</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>More</source>
         <translation>Más</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="50"/>
+        <location filename="../qml/pages/Help.qml" line="46"/>
         <source>This help is a draft! It may be updated?! :-)</source>
         <translation>¡Esta ayuda es un borrador! ¡¿Se puede actualizar?! :-)</translation>
     </message>

--- a/translations/harbour-allradio-it.ts
+++ b/translations/harbour-allradio-it.ts
@@ -1175,62 +1175,62 @@
 <context>
     <name>Help</name>
     <message>
-        <location filename="../qml/pages/Help.qml" line="15"/>
+        <location filename="../qml/pages/Help.qml" line="19"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="33"/>
+        <location filename="../qml/pages/Help.qml" line="29"/>
         <source>Opening webpage</source>
         <translation>Apro pagina web</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="37"/>
+        <location filename="../qml/pages/Help.qml" line="33"/>
         <source>Basics</source>
         <translation>Le basi</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="38"/>
+        <location filename="../qml/pages/Help.qml" line="34"/>
         <source>Choose country by clicking the flag/name, then click the channel you want to listen to</source>
         <translation>Scegli il paese premendo sulla bandiera o il nome, quindi premi sul canale che vuoi ascoltare</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="40"/>
+        <location filename="../qml/pages/Help.qml" line="36"/>
         <source>When playing you will see the name and country-flag of the current playing radio station at the bottom of the screen.</source>
         <translation>Durante la riproduzione vederai in fondo allo schermo il nome e la bandiera del paese dell&apos;attuale stazione radio.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="41"/>
+        <location filename="../qml/pages/Help.qml" line="37"/>
         <source>You can change the country selection between list and icons by flicking down and select &apos;show as list&apos; alt. &apos;show as grid&apos;</source>
         <translation>Puoi cambiare la selezione del paese tra lista ed icone, scorrendo in basso il menu e scegliendo &apos;Mostra come lista&apos; o &apos;Mostra come griglia&apos;</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="43"/>
+        <location filename="../qml/pages/Help.qml" line="39"/>
         <source>Searching</source>
         <translation>Ricerca</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="45"/>
+        <location filename="../qml/pages/Help.qml" line="41"/>
         <source>When you have clicked on the country and are in the channels page, you can click the looking-glass at the top of the list to search/filter the selection based on channel name</source>
         <translation>Una volta premuto sul paese ed andato nella pagina dei canali, puoi premere sulla lente d&apos;ingrandimento in cima alla lista per cercare/filtrare la selezione in base al nome del canale</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="47"/>
+        <location filename="../qml/pages/Help.qml" line="43"/>
         <source>Sleeptimer</source>
         <translation>Tempo di spegnimento</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>Flick down and select sleeptimer, then set the time in minutes until you want the radio to stop playing</source>
         <translation>Scorri in basso il menu e scegli Tempo di spegnimenti, quindi imposta il numero di minuti dopo i quali la radio si spegnerà</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>More</source>
         <translation>Altro</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="50"/>
+        <location filename="../qml/pages/Help.qml" line="46"/>
         <source>This help is a draft! It may be updated?! :-)</source>
         <translation>Questa guida è una bozza! Può essere aggiornata!? :)</translation>
     </message>

--- a/translations/harbour-allradio-nl.ts
+++ b/translations/harbour-allradio-nl.ts
@@ -1175,62 +1175,62 @@
 <context>
     <name>Help</name>
     <message>
-        <location filename="../qml/pages/Help.qml" line="15"/>
+        <location filename="../qml/pages/Help.qml" line="19"/>
         <source>Help</source>
         <translation>Hulp</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="33"/>
+        <location filename="../qml/pages/Help.qml" line="29"/>
         <source>Opening webpage</source>
         <translation>Bezig met openen van webpagina</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="37"/>
+        <location filename="../qml/pages/Help.qml" line="33"/>
         <source>Basics</source>
         <translation>Basis</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="38"/>
+        <location filename="../qml/pages/Help.qml" line="34"/>
         <source>Choose country by clicking the flag/name, then click the channel you want to listen to</source>
         <translation>Kies een land door te tikken op de vlag/naam en tik daarna op het kanaal dat je wil beluisteren</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="40"/>
+        <location filename="../qml/pages/Help.qml" line="36"/>
         <source>When playing you will see the name and country-flag of the current playing radio station at the bottom of the screen.</source>
         <translation>Tijdens het afspelen worden de naam landsvlag van het huidige radiostation weergegeven onderaan het scherm.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="41"/>
+        <location filename="../qml/pages/Help.qml" line="37"/>
         <source>You can change the country selection between list and icons by flicking down and select &apos;show as list&apos; alt. &apos;show as grid&apos;</source>
         <translation>Je kan in de landselectie kiezen tussen lijst en pictogrammen door omlaag te vegen en te kiezen voor &apos;weergeven als lijst&apos; of &apos;weergeven als raster&apos;</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="43"/>
+        <location filename="../qml/pages/Help.qml" line="39"/>
         <source>Searching</source>
         <translation>Bezig met zoeken</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="45"/>
+        <location filename="../qml/pages/Help.qml" line="41"/>
         <source>When you have clicked on the country and are in the channels page, you can click the looking-glass at the top of the list to search/filter the selection based on channel name</source>
         <translation>Als je op het land hebt getikt en je je op de kanalenpagina bevindt kan je klikken op het vergrootglas bovenaan de lijst om te zoeken/filteren</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="47"/>
+        <location filename="../qml/pages/Help.qml" line="43"/>
         <source>Sleeptimer</source>
         <translation>Slaaptimer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>Flick down and select sleeptimer, then set the time in minutes until you want the radio to stop playing</source>
         <translation>Veeg omlaag en selecteer slaaptimer. Stel dan de tijd in in minuten wanneer de radio moet stoppen met afspelen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>More</source>
         <translation>Meer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="50"/>
+        <location filename="../qml/pages/Help.qml" line="46"/>
         <source>This help is a draft! It may be updated?! :-)</source>
         <translation>Deze hulpsectie is een werk in uitvoering! Het kan worden bijgewerkt?! :-)</translation>
     </message>

--- a/translations/harbour-allradio-ru.ts
+++ b/translations/harbour-allradio-ru.ts
@@ -1175,62 +1175,62 @@
 <context>
     <name>Help</name>
     <message>
-        <location filename="../qml/pages/Help.qml" line="15"/>
+        <location filename="../qml/pages/Help.qml" line="19"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="33"/>
+        <location filename="../qml/pages/Help.qml" line="29"/>
         <source>Opening webpage</source>
         <translation>Открытие веб-страницы</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="37"/>
+        <location filename="../qml/pages/Help.qml" line="33"/>
         <source>Basics</source>
         <translation>Основы</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="38"/>
+        <location filename="../qml/pages/Help.qml" line="34"/>
         <source>Choose country by clicking the flag/name, then click the channel you want to listen to</source>
         <translation>Выберите страну коснувшись ее названия или флага, затем выберите радиостанцию, которую хотите слушать.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="40"/>
+        <location filename="../qml/pages/Help.qml" line="36"/>
         <source>When playing you will see the name and country-flag of the current playing radio station at the bottom of the screen.</source>
         <translation>Во время прослушивания радио в нижней части экрана отображается название и флаг страны текущей радиостанции.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="41"/>
+        <location filename="../qml/pages/Help.qml" line="37"/>
         <source>You can change the country selection between list and icons by flicking down and select &apos;show as list&apos; alt. &apos;show as grid&apos;</source>
         <translation>При поиске стран можно выбрать один из двух способов их отображения &apos;Показать списком&apos; или &apos;Показать флаги&apos;</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="43"/>
+        <location filename="../qml/pages/Help.qml" line="39"/>
         <source>Searching</source>
         <translation>Поиск</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="45"/>
+        <location filename="../qml/pages/Help.qml" line="41"/>
         <source>When you have clicked on the country and are in the channels page, you can click the looking-glass at the top of the list to search/filter the selection based on channel name</source>
         <translation>После выбора страны вы попадете в список радиостанций. Значок лупы сверху позволяет искать и фильтровать станции по названиям.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="47"/>
+        <location filename="../qml/pages/Help.qml" line="43"/>
         <source>Sleeptimer</source>
         <translation>Таймер выключения</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>Flick down and select sleeptimer, then set the time in minutes until you want the radio to stop playing</source>
         <translation>Откройте меню, выберите команду &apos;Таймер выключения&apos; и задайте время в минутах, когда радио должно отключиться.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>More</source>
         <translation>Еще</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="50"/>
+        <location filename="../qml/pages/Help.qml" line="46"/>
         <source>This help is a draft! It may be updated?! :-)</source>
         <translation>Эта краткая справка неполна и может измениться :-)</translation>
     </message>

--- a/translations/harbour-allradio-sv.ts
+++ b/translations/harbour-allradio-sv.ts
@@ -1175,62 +1175,62 @@
 <context>
     <name>Help</name>
     <message>
-        <location filename="../qml/pages/Help.qml" line="15"/>
+        <location filename="../qml/pages/Help.qml" line="19"/>
         <source>Help</source>
         <translation>Hjälp</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="33"/>
+        <location filename="../qml/pages/Help.qml" line="29"/>
         <source>Opening webpage</source>
         <translation>Öppnar websida</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="37"/>
+        <location filename="../qml/pages/Help.qml" line="33"/>
         <source>Basics</source>
         <translation>Grunderna</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="38"/>
+        <location filename="../qml/pages/Help.qml" line="34"/>
         <source>Choose country by clicking the flag/name, then click the channel you want to listen to</source>
         <translation>Välj land genom att trycka på flaggan/namnet, tryck sedan på den kanal du vill lyssna till</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="40"/>
+        <location filename="../qml/pages/Help.qml" line="36"/>
         <source>When playing you will see the name and country-flag of the current playing radio station at the bottom of the screen.</source>
         <translation>Under uppspelning ser du radiostationens namn och flagga i botten på skärmen.</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="41"/>
+        <location filename="../qml/pages/Help.qml" line="37"/>
         <source>You can change the country selection between list and icons by flicking down and select &apos;show as list&apos; alt. &apos;show as grid&apos;</source>
         <translation>Du kan välja att se länderna som ikoner eller lista genom att dra ner toppmenyn och välja &apos;Visa som lista&apos; eller &apos;Visa som ikoner&apos;</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="43"/>
+        <location filename="../qml/pages/Help.qml" line="39"/>
         <source>Searching</source>
         <translation>Sökning</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="45"/>
+        <location filename="../qml/pages/Help.qml" line="41"/>
         <source>When you have clicked on the country and are in the channels page, you can click the looking-glass at the top of the list to search/filter the selection based on channel name</source>
         <translation>När du har valt land och tryckt in dig på kanalerna, kan du trycka på förstoringsglaset i toppen av skärmen för att söka/filtrera stationsurvalet, baserat på stationsnamn</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="47"/>
+        <location filename="../qml/pages/Help.qml" line="43"/>
         <source>Sleeptimer</source>
         <translation>Insomningstimer</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>Flick down and select sleeptimer, then set the time in minutes until you want the radio to stop playing</source>
         <translation>Dra ner toppmenyn och välj insomningstimer, ställ sedan in tiden i det antal minuter du vill ha innan radion avslutar uppspelningen</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>More</source>
         <translation>Annat</translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="50"/>
+        <location filename="../qml/pages/Help.qml" line="46"/>
         <source>This help is a draft! It may be updated?! :-)</source>
         <translation>Denna hjälp är ett utkast! Den kan bli uppdaterad!? :-)</translation>
     </message>

--- a/translations/harbour-allradio.ts
+++ b/translations/harbour-allradio.ts
@@ -1175,62 +1175,62 @@
 <context>
     <name>Help</name>
     <message>
-        <location filename="../qml/pages/Help.qml" line="15"/>
+        <location filename="../qml/pages/Help.qml" line="19"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="33"/>
+        <location filename="../qml/pages/Help.qml" line="29"/>
         <source>Opening webpage</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="37"/>
+        <location filename="../qml/pages/Help.qml" line="33"/>
         <source>Basics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="38"/>
+        <location filename="../qml/pages/Help.qml" line="34"/>
         <source>Choose country by clicking the flag/name, then click the channel you want to listen to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="40"/>
+        <location filename="../qml/pages/Help.qml" line="36"/>
         <source>When playing you will see the name and country-flag of the current playing radio station at the bottom of the screen.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="41"/>
+        <location filename="../qml/pages/Help.qml" line="37"/>
         <source>You can change the country selection between list and icons by flicking down and select &apos;show as list&apos; alt. &apos;show as grid&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="43"/>
+        <location filename="../qml/pages/Help.qml" line="39"/>
         <source>Searching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="45"/>
+        <location filename="../qml/pages/Help.qml" line="41"/>
         <source>When you have clicked on the country and are in the channels page, you can click the looking-glass at the top of the list to search/filter the selection based on channel name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="47"/>
+        <location filename="../qml/pages/Help.qml" line="43"/>
         <source>Sleeptimer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>Flick down and select sleeptimer, then set the time in minutes until you want the radio to stop playing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="49"/>
+        <location filename="../qml/pages/Help.qml" line="45"/>
         <source>More</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/Help.qml" line="50"/>
+        <location filename="../qml/pages/Help.qml" line="46"/>
         <source>This help is a draft! It may be updated?! :-)</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
The text used to start at the same offset as the page header / back
navigation indicator.